### PR TITLE
add additional fetch argument types

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,16 +26,16 @@ export function generateMethod(options) {
  * @param {any} options
  * @returns {string}
  */
-export function generateHeader(options) {
-  const headers = options.headers;
+export function generateHeader(headers) {
   let isEncode = false;
   if (!headers) return '';
   let headerParam = '';
-  Object.keys(headers).map((val, key) => {
-    if (val.toLocaleLowerCase() !== 'content-length') {
-      headerParam += ` -H "${val}: ${headers[val].replace(/(\\|")/g, '\\$1')}"`;
+  headers.forEach((val, key) => {
+    console.log()
+    if (key.toLocaleLowerCase() !== 'content-length') {
+      headerParam += ` -H "${key}: ${val.replace(/(\\|")/g, '\\$1')}"`;
     }
-    if (val.toLocaleLowerCase() === 'accept-encoding') {
+    if (key.toLocaleLowerCase() === 'accept-encoding') {
       isEncode = true;
     }
   });
@@ -76,9 +76,15 @@ export function generateCompress(isEncode) {
  * @param {Object} options
  * @param {string} [options.body]
  */
-export const fetchToCurl = (url, options) => {
+const fetchToCurl = (requestInfo, requestInit) => {
+  const url = typeof requestInfo === 'string' ? requestInfo : requestInfo.url;
+  const options = typeof requestInfo === 'string' ? requestInit : requestInfo;
+  const fetchHeaders = options.headers ?
+    (typeof options.headers.forEach === 'function' ? options.headers : new Headers(options.headers)) :
+    null;
+
   const { body } = options;
-  const headers = generateHeader(options);
+  const headers = generateHeader(fetchHeaders);
   return `curl ${url}${generateMethod(options)}${headers.params}${generateBody(body)}${generateCompress(headers.isEncode)}`;
 }
 


### PR DESCRIPTION
The fetch function is overloaded and can be also called with other argument types as currently implemented in fetch-to-curl. It can be a string as first argument and a requestInit object as second argument. But it is also valid to call with an request object type as first argument. 
See 
https://developer.mozilla.org/de/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax

I changed the the code, so that both argument types are possible.