### PR TITLE
Prevent shell from misinterpreting ampersands

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -79,7 +79,7 @@ export function generateCompress(isEncode) {
 export const fetchToCurl = (url, options) => {
   const { body } = options;
   const headers = generateHeader(options);
-  return `curl ${url}${generateMethod(options)}${headers.params}${generateBody(body)}${generateCompress(headers.isEncode)}`;
+  return `curl "${url}"${generateMethod(options)}${headers.params}${generateBody(body)}${generateCompress(headers.isEncode)}`;
 }
 
 export default fetchToCurl;


### PR DESCRIPTION
Should the `url` string contain multiple query parameters it will likely contain an ampersand. In that case if the url argument passed to the curl is unquoted, when run the shell will interpret the ampersand as a control operator.