### PR TITLE
fix tests for empty options of generateHeader

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,12 +26,11 @@ export function generateMethod(options) {
  * @param {any} options
  * @returns {string}
  */
-export function generateHeader(options) {
-  const headers = options.headers;
+export const generateHeader = (options = {}) => {
+  const { headers = {} } = options;
   let isEncode = false;
-  if (!headers) return '';
   let headerParam = '';
-  Object.keys(headers).map((val, key) => {
+  Object.keys(headers).map(val => {
     if (val.toLocaleLowerCase() !== 'content-length') {
       headerParam += ` -H "${val}: ${headers[val].replace(/(\\|")/g, '\\$1')}"`;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,17 @@ export function generateMethod(options) {
 }
 
 /**
+ * @typedef {Object} Headers
+ * @property {Boolean} isEncode - A flag which is set to true if the request should set the --compressed flag
+ * @property {String} params - The header params as string
+ */
+
+/**
  *
  *
  * @export
  * @param {any} options
- * @returns {string}
+ * @returns {Headers} An Object with the header info
  */
 export const generateHeader = (options = {}) => {
   const { headers = {} } = options;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -51,9 +51,36 @@ describe('Generate method param', () => {
 });
 
 describe('Generate header param', () => {
-  test('No Header Option', () => {
-    expect(generateHeader({})).toEqual('');
+  test('No Header Options', () => {
+    expect(generateHeader()).toEqual({
+      isEncode: false,
+      params: ""
+    });
   });
+
+  test('Empty Header Options', () => {
+    expect(generateHeader({})).toEqual({
+      isEncode: false,
+      params: ""
+    });
+  });
+
+  test('Has Encoded Header', () => {
+    const option = {
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+        'User-Agent': 'axios/0.18.0',
+        'accept-encoding': 'gzip'
+      }
+    };
+    const result = {
+      isEncode: true,
+      params:
+        ' -H "Accept: application/json, text/plain, */*" -H "User-Agent: axios/0.18.0" -H "accept-encoding: gzip"'
+    };
+    expect(generateHeader(option)).toEqual(result);
+  });
+
   test('Has Header', () => {
     const option = {
       headers: {


### PR DESCRIPTION
This is a follow up to #16 which fixed #15 and addresses the issues raised in https://github.com/leoek/fetch-to-curl/pull/16#pullrequestreview-297063165