### PR TITLE
Support fetching URL objects

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -118,7 +118,7 @@ export const fetchToCurl = (requestInfo, requestInit) => {
    * initialization with an empty object is done here to
    * keep everything backwards compatible to 0.4.0 and below
    */
-  if (typeof requestInfo === "string") {
+  if (typeof requestInfo === "string" || requestInfo instanceof URL) {
     url = requestInfo;
     options = requestInit || {};
   } else {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -198,19 +198,25 @@ describe('Generate Compress param', () => {
 });
 
 describe('fetchToCurl', () => {
-  test('url and empty options', () => {
+  test('url string and empty options', () => {
     expect(
       fetchToCurl('google.com', {})
     ).toEqual("curl 'google.com'");
   });
 
-  test('url and no options', () => {
+  test('url object and empty options', () => {
+    expect(
+      fetchToCurl(new URL('https://google.com/'), {})
+    ).toEqual("curl 'https://google.com/'");
+  });
+
+  test('url string and no options', () => {
     expect(
       fetchToCurl('google.com')
     ).toEqual("curl 'google.com'");
   });
 
-  test('url and Request Object', () => {
+  test('url string and Request Object', () => {
     expect(
       fetchToCurl('google.com', { method: "POST" })
     ).toEqual("curl 'google.com' -X POST");


### PR DESCRIPTION
This adds support for URL objects. Currently, trying to call `fetchToCurl` with a URL object results in `curl 'undefined'` being returned.