### PR TITLE
Fix issue with empty headers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ export const isInstanceOfHeaders = (val) => {
  * @property {String} params - The header params as string
  */
 
-const getHeaderString = (name, val) => ` -H "${name}: ${(val || '').replace(/(\\|")/g, '\\$1')}"`;
+const getHeaderString = (name, val) => ` -H "${name}: ${`${val}`.replace(/(\\|")/g, '\\$1')}"`;
 
 /**
  * @export

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ export const isInstanceOfHeaders = (val) => {
  * @property {String} params - The header params as string
  */
 
-const getHeaderString = (name, val) => ` -H "${name}: ${val.replace(/(\\|")/g, '\\$1')}"`;
+const getHeaderString = (name, val) => ` -H "${name}: ${(val || '').replace(/(\\|")/g, '\\$1')}"`;
 
 /**
  * @export


### PR DESCRIPTION
If for some reason a header value is undefined/null, we get an error (`can't call function replace of undefined`). We could filter out empty headers also, but if the header is there and empty, maybe we'd still want it output?