### PR TITLE
Fix exporting the named export in type declarations 

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -28,7 +28,7 @@ export interface FetchOptions {
     [rest: string]: any 
 }
 
-declare function fetchToCurl(
+export declare function fetchToCurl(
     requestInfo: string | FetchOptions,
     requestInit?: FetchOptions
 ): string;


### PR DESCRIPTION
The `export` keyword was missing.